### PR TITLE
docs(readme): fix repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cargo install cargo-generate
 2. Clone this repository via `cargo-generate`:
 
 ```sh
-cargo generate --git https://github.com/orhun/rust-tui-template --name <project-name>
+cargo generate --git https://github.com/tui-rs-revival/rust-tui-template --name <project-name>
 ```
 
 ## See also


### PR DESCRIPTION
I wasn't sure if this was intentional or not. The current link redirects to this repo in my web browser anyway.