### PR TITLE
refactor(app): remove rendering from `app.rs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ A template for bootstrapping a Rust [**TUI**](https://en.wikipedia.org/wiki/Text
 
 ```
 src/
-├── app.rs     -> holds the states and renders the widgets
+├── app.rs     -> holds the state and application logic
 ├── event.rs   -> handles the terminal events (key press, mouse click, resize, etc.)
 ├── handler.rs -> handles the key press events and updates the application
 ├── lib.rs     -> module definitions
 ├── main.rs    -> entry-point
-└── tui.rs     -> initializes/exits the terminal interface
+├── tui.rs     -> initializes/exits the terminal interface
+└── ui.rs      -> renders the widgets / UI
 ```
 
 ## Usage

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,4 @@
 use std::error;
-use tui::backend::Backend;
-use tui::layout::Alignment;
-use tui::style::{Color, Style};
-use tui::terminal::Frame;
-use tui::widgets::{Block, BorderType, Borders, Paragraph};
 
 /// Application result type.
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
@@ -30,26 +25,8 @@ impl App {
     /// Handles the tick event of the terminal.
     pub fn tick(&self) {}
 
-    /// Renders the user interface widgets.
-    pub fn render<B: Backend>(&mut self, frame: &mut Frame<'_, B>) {
-        // This is where you add new widgets.
-        // See the following resources:
-        // - https://docs.rs/ratatui/latest/ratatui/widgets/index.html
-        // - https://github.com/tui-rs-revival/ratatui/tree/master/examples
-        frame.render_widget(
-            Paragraph::new(
-                "This is a tui template.\nPress `Esc`, `Ctrl-C` or `q` to stop running.",
-            )
-            .block(
-                Block::default()
-                    .title("Template")
-                    .title_alignment(Alignment::Center)
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded),
-            )
-            .style(Style::default().fg(Color::Cyan).bg(Color::Black))
-            .alignment(Alignment::Center),
-            frame.size(),
-        )
+    /// Set running to false to quit the applcation.
+    pub fn quit(&mut self) {
+        self.running = false;
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,11 +8,16 @@ pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 pub struct App {
     /// Is the application running?
     pub running: bool,
+    /// counter
+    pub counter: u8,
 }
 
 impl Default for App {
     fn default() -> Self {
-        Self { running: true }
+        Self {
+            running: true,
+            counter: 0,
+        }
     }
 }
 
@@ -25,8 +30,20 @@ impl App {
     /// Handles the tick event of the terminal.
     pub fn tick(&self) {}
 
-    /// Set running to false to quit the applcation.
+    /// Set running to false to quit the application.
     pub fn quit(&mut self) {
         self.running = false;
+    }
+
+    pub fn increment_counter(&mut self) {
+        if let Some(res) = self.counter.checked_add(1) {
+            self.counter = res;
+        }
+    }
+
+    pub fn decrement_counter(&mut self) {
+        if let Some(res) = self.counter.checked_sub(1) {
+            self.counter = res;
+        }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -14,6 +14,13 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 app.quit();
             }
         }
+        // Counter handlers
+        KeyCode::Right => {
+            app.increment_counter();
+        }
+        KeyCode::Left => {
+            app.decrement_counter();
+        }
         // Other handlers you could add here.
         _ => {}
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,12 +6,12 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
     match key_event.code {
         // Exit application on `ESC` or `q`
         KeyCode::Esc | KeyCode::Char('q') => {
-            app.running = false;
+            app.quit();
         }
         // Exit application on `Ctrl-C`
         KeyCode::Char('c') | KeyCode::Char('C') => {
             if key_event.modifiers == KeyModifiers::CONTROL {
-                app.running = false;
+                app.quit();
             }
         }
         // Other handlers you could add here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ pub mod app;
 /// Terminal events handler.
 pub mod event;
 
+/// Widget renderer.
+pub mod ui;
+
 /// Terminal user interface.
 pub mod tui;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,6 @@
 use crate::app::{App, AppResult};
 use crate::event::EventHandler;
+use crate::ui;
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use std::io;
@@ -40,7 +41,7 @@ impl<B: Backend> Tui<B> {
     /// [`Draw`]: tui::Terminal::draw
     /// [`rendering`]: crate::app::App::render
     pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
-        self.terminal.draw(|frame| app.render(frame))?;
+        self.terminal.draw(|frame| ui::render(app, frame))?;
         Ok(())
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -39,7 +39,7 @@ impl<B: Backend> Tui<B> {
     /// [`Draw`] the terminal interface by [`rendering`] the widgets.
     ///
     /// [`Draw`]: tui::Terminal::draw
-    /// [`rendering`]: crate::app::App::render
+    /// [`rendering`]: crate::ui:render
     pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
         self.terminal.draw(|frame| ui::render(app, frame))?;
         Ok(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,7 +9,7 @@ use tui::{
 use crate::app::App;
 
 /// Renders the user interface widgets.
-pub fn render<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+pub fn render<B: Backend>(_app: &mut App, frame: &mut Frame<'_, B>) {
     // This is where you add new widgets.
     // See the following resources:
     // - https://docs.rs/ratatui/latest/ratatui/widgets/index.html

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,30 @@
+use tui::{
+    backend::Backend,
+    layout::Alignment,
+    style::{Color, Style},
+    widgets::{Block, BorderType, Borders, Paragraph},
+    Frame,
+};
+
+use crate::app::App;
+
+/// Renders the user interface widgets.
+pub fn render<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
+    // This is where you add new widgets.
+    // See the following resources:
+    // - https://docs.rs/ratatui/latest/ratatui/widgets/index.html
+    // - https://github.com/tui-rs-revival/ratatui/tree/master/examples
+    frame.render_widget(
+        Paragraph::new("This is a tui template.\nPress `Esc`, `Ctrl-C` or `q` to stop running.")
+            .block(
+                Block::default()
+                    .title("Template")
+                    .title_alignment(Alignment::Center)
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded),
+            )
+            .style(Style::default().fg(Color::Cyan).bg(Color::Black))
+            .alignment(Alignment::Center),
+        frame.size(),
+    )
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,22 +9,28 @@ use tui::{
 use crate::app::App;
 
 /// Renders the user interface widgets.
-pub fn render<B: Backend>(_app: &mut App, frame: &mut Frame<'_, B>) {
+pub fn render<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>) {
     // This is where you add new widgets.
     // See the following resources:
     // - https://docs.rs/ratatui/latest/ratatui/widgets/index.html
     // - https://github.com/tui-rs-revival/ratatui/tree/master/examples
     frame.render_widget(
-        Paragraph::new("This is a tui template.\nPress `Esc`, `Ctrl-C` or `q` to stop running.")
-            .block(
-                Block::default()
-                    .title("Template")
-                    .title_alignment(Alignment::Center)
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded),
-            )
-            .style(Style::default().fg(Color::Cyan).bg(Color::Black))
-            .alignment(Alignment::Center),
+        Paragraph::new(format!(
+            "This is a tui template.\n\
+                Press `Esc`, `Ctrl-C` or `q` to stop running.\n\
+                Press left and right to increment and decrement the counter respectively.\n\
+                Counter: {}",
+            app.counter
+        ))
+        .block(
+            Block::default()
+                .title("Template")
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded),
+        )
+        .style(Style::default().fg(Color::Cyan).bg(Color::Black))
+        .alignment(Alignment::Center),
         frame.size(),
     )
 }


### PR DESCRIPTION
closes #3 

I also added a little counter demo in the 2nd last commit here, but I can revert it. Just wanted to give `ui::render` a simple use for the app parameter; but this might be out of scope for a template so I'm happy to revert it or make any changes requested.

Thanks :) 