### PR TITLE
test(ci): add github action to ensure build succeeds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: 'Build Template'
+on:
+  workflow_dispatch:
+  schedule:
+    # Run once a week at 6pm on Saturday (UTC)
+    - cron: '0 18 * * 6'
+  push:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_NAME: my-project
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cargo-generate/cargo-generate-action@v0.17.5
+        with:
+          name: ${{ env.PROJECT_NAME }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      # We need to move the generated project to a temp folder, away from the template project
+      # otherwise `cargo` runs would fail .
+      # see https://github.com/rust-lang/cargo/issues/9922
+      - run: |
+          mv $PROJECT_NAME ${{ runner.temp }}/
+          cd ${{ runner.temp }}/$PROJECT_NAME
+          cargo check
+


### PR DESCRIPTION
Cargo generate docs recommend setting up a github action to ensure that your templates build succeeds. I think this is a good thing to have as I was unable to get the regular rust tooling to work without creating a new project from my local clone of this repo.

I mostly copied this build.yml from their docs: 
https://cargo-generate.github.io/cargo-generate/templates/authoring.html

but made a few minor changes:
- used `cargo-generate/cargo-generate-action@v0.17.5` instead of `v0.17`, as `v0.17 `does not exist anymore
- used `dtolnay/rust-toolchain@stable` instead of `actions-rs/toolchain@v1` as `actions-rs` is abandoned
- made the weekly cronjob run on Saturday instead of Friday
- removed `**/docs/**` from the paths-ignore as no directory matches that for this repo

Here's an example of a failed build when introducing an intentional typo in a template placeholder: https://github.com/loadedice/rust-tui-template/actions/runs/4636065654/jobs/8203626339

