### PR TITLE
Bump ratatui to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 crossterm = "0.26.1"
-tui = { package = "ratatui", version = "0.20.1" }
+tui = { package = "ratatui", version = "0.21.0" }


### PR DESCRIPTION
From 0.20.1 to 0.21.0
a.k.a. the switch from tui-rs to ratatui.