### PR TITLE
Introduce cargo-generate.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 # Test the builds for the template
-#
 
 name: "Build Template"
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,5 @@
 # Test the builds for the template
 #
-# When you got this file through:
-#   cargo generate --git https://github.com/tui-rs-revival/rust-tui-template --name <project-name>
-# you can deleted it safely. (Above directories also.)
-#
-# By the way: Enjoy the template :-)
 
 name: "Build Template"
 on:

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,9 +1,4 @@
-#
-# cargo-generate.toml
-#   documented at https://cargo-generate.github.io/cargo-generate/
-#
+# configuration for https://cargo-generate.github.io/cargo-generate/
+
 [template]
-ignore = [
-  "README.md",
-  ".github/",
-]
+ignore = ["README.md", ".github/"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,9 @@
+#
+# cargo-generate.toml
+#   documented at https://cargo-generate.github.io/cargo-generate/
+#
+[template]
+ignore = [
+  "README.md",
+  ".github/",
+]


### PR DESCRIPTION
Initial use case is preventing distracting files
in the generated project.

Having `cargo generate` to ignore the .github directory, makes it possible to remove header text from .github/workflows/build.yml about file is not needed in the fresh generated project.